### PR TITLE
feat: Add Datastore clusterRole and add labels to cnp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Create clusterRole for kamaji-etcd Datastore CRs.
+
 ## [0.2.2] - 2026-03-02
 
 ### Changed

--- a/helm/kamaji/Chart.yaml
+++ b/helm/kamaji/Chart.yaml
@@ -9,12 +9,12 @@ maintainers:
     email: team-rocket@giantswarm.io
 name: kamaji
 sources:
-  - https://github.com/clastix/kamaji
+- https://github.com/clastix/kamaji
 type: application
 version: 0.2.2
 dependencies:
-  - name: kamaji-crds
-    version: 0.2.1
+- name: kamaji-crds
+  version: 0.2.2
 annotations:
   io.giantswarm.application.team: "rocket"
   io.giantswarm.application.audience: "giantswarm"

--- a/helm/kamaji/charts/kamaji-crds/Chart.yaml
+++ b/helm/kamaji/charts/kamaji-crds/Chart.yaml
@@ -10,7 +10,7 @@ name: kamaji-crds
 sources:
   - https://github.com/clastix/kamaji
 type: application
-version: 0.2.1
+version: 0.2.2
 annotations:
   io.giantswarm.application.team: "rocket"
   io.giantswarm.application.audience: "giantswarm"

--- a/helm/kamaji/templates/cnp.yaml
+++ b/helm/kamaji/templates/cnp.yaml
@@ -3,6 +3,8 @@ kind: CiliumNetworkPolicy
 metadata:
   name: kamaji
   namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kamaji.labels" . | nindent 4 }}
 spec:
   endpointSelector:
     matchLabels:

--- a/helm/kamaji/templates/kamaji-etcd-clusterrole.yaml
+++ b/helm/kamaji/templates/kamaji-etcd-clusterrole.yaml
@@ -1,0 +1,19 @@
+# ClusterRole for DataStore (cluster-scoped resource)
+# The ClusterRoleBinding is created in each org namespace by rbac-operator. See: https://github.com/giantswarm/rbac-operator/pull/724
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kamaji-etcd-helmrelease-datastores
+  labels:
+    {{- include "kamaji.labels" . | nindent 4 }}
+rules:
+  - apiGroups: ["kamaji.clastix.io"]
+    resources:
+      - datastores
+    verbs:
+      - delete
+      - get
+      - patch
+      - update
+      - create
+      - list

--- a/sync/overwrites/kamaji/templates/cnp.yaml
+++ b/sync/overwrites/kamaji/templates/cnp.yaml
@@ -3,6 +3,8 @@ kind: CiliumNetworkPolicy
 metadata:
   name: kamaji
   namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kamaji.labels" . | nindent 4 }}
 spec:
   endpointSelector:
     matchLabels:

--- a/sync/overwrites/kamaji/templates/kamaji-etcd-clusterrole.yaml
+++ b/sync/overwrites/kamaji/templates/kamaji-etcd-clusterrole.yaml
@@ -1,0 +1,19 @@
+# ClusterRole for DataStore (cluster-scoped resource)
+# The ClusterRoleBinding is created in each org namespace by rbac-operator. See: https://github.com/giantswarm/rbac-operator/pull/724
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kamaji-etcd-helmrelease-datastores
+  labels:
+    {{- include "kamaji.labels" . | nindent 4 }}
+rules:
+  - apiGroups: ["kamaji.clastix.io"]
+    resources:
+      - datastores
+    verbs:
+      - delete
+      - get
+      - patch
+      - update
+      - create
+      - list


### PR DESCRIPTION
The `automation` SA in org namespaces need permissions to create Datastore CRs to create etcd cluster for WCs.

We create the clusterRole here and then apply it in each org ns with rbac-operator (https://github.com/giantswarm/rbac-operator/pull/724).
It is not perfect because the SA in org A could delete a datastore used in org B but this is the nature of Datastores being cluster scoped (why are they?..).
Datastores are still protected by finalizers so it could be worse.

