### PR TITLE
chore: update kamaji app icon to v2 light.svg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Create clusterRole for kamaji-etcd Datastore CRs.
 
+### Changed
+
+- Update app icon to the v2 Giant Swarm kamaji icon.
+
 ## [0.2.2] - 2026-03-02
 
 ### Changed

--- a/helm/kamaji/Chart.yaml
+++ b/helm/kamaji/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: edge-25.12.3
 description: Kamaji is the Hosted Control Plane Manager for Kubernetes.
 home: https://github.com/giantswarm/kamaji-app
-icon: https://s.giantswarm.io/app-icons/kamaji/1/light.png
+icon: https://s.giantswarm.io/app-icons/kamaji/2/light.svg
 kubeVersion: ">=1.21.0-0"
 maintainers:
   - name: Team Rocket

--- a/sync/patches/kamaji/chart/_chart.patch
+++ b/sync/patches/kamaji/chart/_chart.patch
@@ -10,7 +10,7 @@ index a7ec5fa..b72d7ef 100644
 -home: https://github.com/clastix/kamaji
 -icon: https://github.com/clastix/kamaji/raw/master/assets/logo-colored.png
 +home: https://github.com/giantswarm/kamaji-app
-+icon: https://s.giantswarm.io/app-icons/kamaji/1/light.png
++icon: https://s.giantswarm.io/app-icons/kamaji/2/light.svg
  kubeVersion: ">=1.21.0-0"
  maintainers:
 -- email: dario@tranchitella.eu


### PR DESCRIPTION
Updates the app icon from the v1 icon (`app-icons/kamaji/1/light.png`) to the new v2 icon `https://s.giantswarm.io/app-icons/kamaji/2/light.svg`.

Both the rendered `helm/kamaji/Chart.yaml` and the `sync/patches/kamaji/chart/_chart.patch` source-of-truth file are updated so the change persists through the next `sync.sh` run.